### PR TITLE
Fix VDF parse errors on empty string lines

### DIFF
--- a/tasks/updateconstants.ts
+++ b/tasks/updateconstants.ts
@@ -1436,6 +1436,8 @@ function parseJsonOrVdf(text: string, url: string) {
       fixed = fixed.replace(/\t\t"ItemRequirements"\r\n\t\t""/g, "");
       fixed = fixed.replace(/\t\t\t"has_flying_movement"\t\r\n\t\t\t""/g, "");
       fixed = fixed.replace(/\t\t\t"damage_reduction"\t\r\n\t\t\t""/g, "");
+      // Remove stray empty string lines that invalidate the VDF
+      fixed = fixed.replace(/^\s*""\r?\n/gm, "");
       const vdf = vdfparser.parse(fixed, { types: false, arrayify: true });
       return vdf;
     } catch (e) {


### PR DESCRIPTION
## Summary
- ignore stray empty string lines before parsing VDF files

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsx tasks/updateconstants.ts` *(fails to run due to interactive dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68571bcb39d88333a90c95f094e5c0a5